### PR TITLE
Fix fetching messages for PDU mode

### DIFF
--- a/sms3/__init__.py
+++ b/sms3/__init__.py
@@ -77,7 +77,8 @@ class Modem(object):
         text = None
         index = None
         date = None
-        for line in self._command('AT+CMGL="ALL"')[:-1]:
+        all_msgs = '"ALL"' if self._mode == MODE.TEXT else '4'
+        for line in self._command('AT+CMGL=%s' % all_msgs)[:-1]:
             m = pat.match(line.decode('ascii'))
             logging.debug(m)
             if m is not None:


### PR DESCRIPTION
In PDU mode, AT+CMGL requires argument in numeric format, not textual:
https://www.diafaan.com/sms-tutorials/gsm-modem-tutorial/at-cmgl-pdu-mode/